### PR TITLE
add a new approval state

### DIFF
--- a/pkg/apis/autopilot/v1alpha1/actionapproval.go
+++ b/pkg/apis/autopilot/v1alpha1/actionapproval.go
@@ -14,6 +14,8 @@ const (
 	ApprovalStateApproved ActionApprovalState = "approved"
 	// ApprovalStateDeclined  means the action has been declined
 	ApprovalStateDeclined ActionApprovalState = "declined"
+	// ApprovalStateCanceled  means the action approval has been canceled
+	ApprovalStateCanceled ActionApprovalState = "canceled"
 )
 
 type (


### PR DESCRIPTION
Required for canceled approvals when a condition is no longer met